### PR TITLE
Fix Heroku Deployment

### DIFF
--- a/src/components/Firebase/firebase.js
+++ b/src/components/Firebase/firebase.js
@@ -2,15 +2,16 @@ import app from 'firebase/app';
 import 'firebase/database';
 
 const firebaseConfig = {
-  apiKey:            process.env.REACT_APP_API_KEY,
-  authDomain:        process.env.REACT_APP_AUTH_DOMAIN,
-  databaseURL:       process.env.REACT_APP_DATABASE_URL,
-  projectId:         process.env.REACT_APP_PROJECT_ID,
-  storageBucket:     process.env.REACT_APP_STORAGE_BUCKET,
-  messagingSenderId: process.env.REACT_APP_MESSAGING_SENDER_ID,
-  appId:             process.env.REACT_APP_APP_ID,
-  measurementId:     process.env.REACT_APP_MEASUREMENT_ID
+    apiKey:            process.env.REACT_APP_API_KEY,
+    authDomain:        process.env.REACT_APP_AUTH_DOMAIN,
+    databaseURL:       process.env.REACT_APP_DATABASE_URL,
+    projectId:         process.env.REACT_APP_PROJECT_ID,
+    storageBucket:     process.env.REACT_APP_STORAGE_BUCKET,
+    messagingSenderId: process.env.REACT_APP_MESSAGING_SENDER_ID,
+    appId:             process.env.REACT_APP_APP_ID,
+    measurementId:     process.env.REACT_APP_MEASUREMENT_ID
 };
+
 
 class Firebase {
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,6 @@
 
 //server.js
-require('dotenv').config();
+//require('dotenv').config();
 const express = require('express');
 const favicon = require('express-favicon');
 const path = require('path');


### PR DESCRIPTION
* Added environment variables to Heroku
* Remove `require(dotenv)` from `server.js`

We need the `require` call on our local machines for testing, but because we don't push it to the repo we can't use it for our production build. When we deployed to Heroku it was looking for a `.env` file that wasn't there.